### PR TITLE
Use python2 as default

### DIFF
--- a/paste.py
+++ b/paste.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # Filename:      paste
 # Purpose:       XmlRpc interface client to paste.debian.net
 # Author:        Michael Gebetsroither <michael@mgeb.org>


### PR DESCRIPTION
If user runs with `./paste.py` it could be that the system uses python3. With this change it will be python2 forced.